### PR TITLE
BUGFIX: pin click version: 8.2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ clean: ## Cleaning previous python virtual environment
 ## Development environment:
 
 serve: ## Run mkdocs server
-	mkdocs serve
+	mkdocs serve --livereload
 
 tags: ## Generate tags index
 	python3 scripts/generate-tags.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,11 @@
+# --- Bugfix: Pin Click to 8.2.1 to resolve MkDocs livereload bug on macOS ---
+click==8.2.1
+
+# Core Theme & Extensions
 mkdocs-material>=9.6
 mdx_truly_sane_lists>=1.3
+
+# Plugins
 mkdocs-awesome-pages-plugin>=2.10
 mkdocs-git-revision-date-localized-plugin>=1.4
 mkdocs-minify-plugin>=0.8


### PR DESCRIPTION
# Bug Report: Regression in File Watching due to Click 8.3.x Default Flag Logic

## Description

This PR addresses an issue where `mkdocs serve` fails to detect file changes on macOS (and other platforms) when running **Click 8.3.0 or 8.3.1**.

The root cause is a regression in `click` regarding how boolean flags with `default=True` are handled. Even though MkDocs defines `--livereload` to be `True` by default, Click 8.3.x incorrectly evaluates this to `False` (or `None`) if the flag is not explicitly passed in the CLI. Consequently, MkDocs initializes the server without "arming" the `LiveReloadServer` observer, leading to a silent failure of the file-watching functionality.

## Environment Replicated

* **Python**: 3.12+
* **Click**: 8.3.0 / 8.3.1
* **MkDocs**: 1.6.1
* **OS**: macOS Sequoia 15.x (Confirmed), potentially all OSs.

## Root Cause Analysis

In Click 8.3.0, changes to the internal parameter parsing logic for `flag_value` options caused a "sentinel" value error. When an option has both `default=True` and `flag_value=True`, the new parser fails to apply the default value to the variable unless the user explicitly provides the flag.

Because MkDocs logic checks `if livereload:` before starting the `watchdog` observer, the observer is never started, and the log line `Watching paths for changes` never appears.

---

## Steps to Reproduce (Minimal Example)

You can reproduce this behavior without MkDocs using this standalone script:

```python
import click
import sys

@click.command()
# This mimics the MkDocs 'serve' flag definition
@click.option('--watch/--no-watch', is_flag=True, default=True)
def test_watch(watch):
    click.echo(f"Click version: {click.__version__}")
    click.echo(f"Watch variable state: {watch}")
    if watch:
        click.echo("✅ Behavior: Correct (Watcher would start)")
    else:
        click.echo("❌ Behavior: Buggy (Watcher remains disabled)")

if __name__ == "__main__":
    test_watch()

```

### Execution Steps:

1. **Install Click 8.3.1**: `pip install click==8.3.1`
2. **Run script**: `python repro.py`
* **Result**: `Watch variable state: False` (Incorrect)


3. **Explicitly pass flag**: `python repro.py --watch`
* **Result**: `Watch variable state: True` (Correct, but ignores default)


4. **Downgrade Click**: `pip install click==8.2.1`
5. **Run script**: `python repro.py`
* **Result**: `Watch variable state: True` (Correct default behavior)



---

## Fix Applied

The `requirements.txt` (or `pyproject.toml`) has been updated to pin `click==8.2.1`.

This ensures that:

1. The `livereload` server is correctly initialized by default.
2. File system events (FSEvents/Watchdog) are properly registered.
3. Users do not need to manually append `--livereload` to the `mkdocs serve` command.

## Verification Results

* **Command**: `mkdocs serve`
* **Output**:
```text
INFO    -  [23:17:03] Watching paths for changes: 'docs', 'mkdocs.yml'
INFO    -  [23:17:19] Detected file changes
INFO    -  Building documentation...

```
