### PR TITLE
Upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -40,15 +40,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python runtime
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Required for git-revision-date-localized-plugin
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python runtime
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -37,7 +37,7 @@ jobs:
         run: uv run python scripts/generate-rss.py
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.SSH_DEPLOY_KEY }}
           external_repository: halyph/halyph.github.io


### PR DESCRIPTION
Updated actions to resolve Node.js 20 deprecation warnings:
- actions/checkout: v4 → v6 (Node.js 24 support)
- actions/setup-python: v5 → v6 (Node.js 24 support)
- astral-sh/setup-uv: v4 → v8 (Node.js 24 support)
- peaceiris/actions-gh-pages: v3 → v4 (Node.js 20, latest available)

Note: peaceiris/actions-gh-pages v4 still uses Node.js 20 as there is no v5 release with Node.js 24 support yet. This is the latest version available and will need future update when v5 is released.

Fixes #200